### PR TITLE
PROBA-V download and preprocessing

### DIFF
--- a/pyWAPOR/Collect/PROBAV/DataAccess.py
+++ b/pyWAPOR/Collect/PROBAV/DataAccess.py
@@ -20,7 +20,8 @@ from pathlib import Path
 from geojson import Polygon
 from requests.exceptions import HTTPError
 from datetime import datetime, timedelta
-
+from aiohttp import ClientResponseError, ServerDisconnectedError
+from asyncio import TimeoutError
 # Required for Python 3.6 and 3.7
 import nest_asyncio
 nest_asyncio.apply()
@@ -80,7 +81,8 @@ def download_data(download_dir, start_date, end_date, latitude_extent, longitude
 
                 download_success = True
 
-            except (RuntimeError, HTTPError):
+            except (RuntimeError, HTTPError,
+                    ClientResponseError, ServerDisconnectedError, TimeoutError):
                 no_of_attempts += 1
                 continue
             break

--- a/pyWAPOR/Collect/PROBAV/DataAccess.py
+++ b/pyWAPOR/Collect/PROBAV/DataAccess.py
@@ -199,23 +199,23 @@ def _merge_and_save_tifs(input_files, output_file, latitude_extent, longitude_ex
     mosaic, mosaic_trans = rasterio.merge.merge(src_files_to_mosaic, bounds=bbox)
     mosaic = np.squeeze(mosaic)
 
-    # check if we have data in aoi
-    if np.any(~((mosaic == 0) | np.isnan(mosaic))):
+    # Do not check if we have data in aoi
 
-        meta = {
-            'driver': 'GTiff',
-            'width': mosaic.shape[1],
-            'height': mosaic.shape[0],
-            'count': 1,
-            'dtype': str(mosaic.dtype),
-            'crs': crs,
-            'transform': mosaic_trans
-        }
 
-        if not os.path.exists(os.path.dirname(output_file)):
-            os.mkdir(os.path.dirname(output_file))
-        with rasterio.open(output_file, 'w', **meta) as dst:
-            dst.write(mosaic, 1)
+    meta = {
+        'driver': 'GTiff',
+        'width': mosaic.shape[1],
+        'height': mosaic.shape[0],
+        'count': 1,
+        'dtype': str(mosaic.dtype),
+        'crs': crs,
+        'transform': mosaic_trans
+    }
+
+    if not os.path.exists(os.path.dirname(output_file)):
+        os.mkdir(os.path.dirname(output_file))
+    with rasterio.open(output_file, 'w', **meta) as dst:
+        dst.write(mosaic, 1)
 
     if delete_input:
         for src in src_files_to_mosaic:


### PR DESCRIPTION
Two main fixes are suggested:
* Track VITO server errors to allow download retry.
* Force the creation of Proba-V 5-day mosaics even if mosaic arrays contain only NaNs. Otherwise a later error is raised when producing the 10-day composites for ETLook